### PR TITLE
Add role to `HtmlAttrs`

### DIFF
--- a/ludic/attrs.py
+++ b/ludic/attrs.py
@@ -56,6 +56,7 @@ class HtmlAttrs(Attrs, total=False):
     ]
     lang: str
     popover: bool
+    role: str
     spellcheck: Literal["true", "false"]
     style: CSSProperties
     tabindex: int


### PR DESCRIPTION
Hey, instead of just filing issues, I figured I should try to do some solutions 😁 

It makes sense for `HtmlAttrs` to have a `role` attr, since all DOM elements are supposed to have it:
https://developer.mozilla.org/en-US/docs/Web/API/Element/role